### PR TITLE
Fix Jack skip in 1v1 mode

### DIFF
--- a/crazy8s-game/backend/src/models/game.js
+++ b/crazy8s-game/backend/src/models/game.js
@@ -338,7 +338,13 @@ class Game {
 
         switch (card.rank) {
             case 'Jack': // Skip
-                this.nextPlayer(); // Skip the next player
+                if (this.activePlayers.length === 2) {
+                    // In 1v1, Jack acts as a normal card (no skip effect)
+                    // Turn will pass normally after this play
+                } else {
+                    // Skip the next player in multiplayer games
+                    this.nextPlayer();
+                }
                 break;
 
             case 'Queen': // Reverse
@@ -439,8 +445,13 @@ class Game {
         for (const card of cardStack) {
             switch (card.rank) {
                 case 'Jack':
-                    // Jack skips opponent, back to us
-                    currentPlayerHasTurn = true;
+                    if (isOneVsOne) {
+                        // In 1v1, Jack acts as a normal card (turn passes)
+                        currentPlayerHasTurn = false;
+                    } else {
+                        // Jack skips opponent, back to us
+                        currentPlayerHasTurn = true;
+                    }
                     break;
                     
                 case 'Queen':
@@ -486,10 +497,15 @@ class Game {
             
             switch (card.rank) {
                 case 'Jack': // Skip
-                    console.log('    Jack: Skipping next player');
-                    // Skip one player and end our turn
-                    this.nextPlayer();
-                    currentPlayerHasTurn = false;
+                    if (this.activePlayers.length === 2) {
+                        console.log('    Jack (1v1): Acts as normal card');
+                        currentPlayerHasTurn = false;
+                    } else {
+                        console.log('    Jack: Skipping next player');
+                        // Skip one player and end our turn
+                        this.nextPlayer();
+                        currentPlayerHasTurn = false;
+                    }
                     break;
 
                 case 'Queen': // Reverse

--- a/crazy8s-game/backend/tests/crazy8.test.js
+++ b/crazy8s-game/backend/tests/crazy8.test.js
@@ -66,16 +66,19 @@ describe('Crazy 8s Game Integration Tests', () => {
 
         test('should handle card drawing', () => {
             game.startGame();
-            
+
             const player = game.getPlayerById('p1');
             const initialHandSize = player.hand.length;
-            
+
             const drawResult = game.drawCards('p1', 2);
             expect(drawResult.success).toBe(true);
             expect(player.hand.length).toBe(initialHandSize + 2);
             expect(drawResult.drawnCards).toHaveLength(2);
-            
-            // Turn should advance after drawing
+            // Player must pass turn after drawing
+            const passResult = game.passTurnAfterDraw('p1');
+            expect(passResult.success).toBe(true);
+
+            // Turn should advance after passing
             expect(game.getCurrentPlayer().name).toBe('Bob');
         });
 

--- a/crazy8s-game/backend/tests/game.test.js
+++ b/crazy8s-game/backend/tests/game.test.js
@@ -239,6 +239,19 @@ describe('Game Class Tests', () => {
             }
         });
 
+        test('Jack should pass turn in 1v1 game', () => {
+            const duelGame = new Game(['p1', 'p2'], ['Alice', 'Bob']);
+            duelGame.startGame();
+            const jack = { suit: 'Hearts', rank: 'Jack' };
+            duelGame.discardPile = [{ suit: 'Hearts', rank: '7' }];
+            duelGame.players[0].hand.push(jack);
+
+            const initialIndex = duelGame.currentPlayerIndex;
+            const result = duelGame.playCard(duelGame.players[0].id, jack);
+            expect(result.success).toBe(true);
+            expect(duelGame.currentPlayerIndex).toBe((initialIndex + 1) % 2);
+        });
+
         test('should handle Queen (Reverse)', () => {
             const queen = { suit: 'Hearts', rank: 'Queen' };
             const currentPlayer = game.getCurrentPlayer();


### PR DESCRIPTION
## Summary
- tweak Jack handling so it doesn't give an extra turn in 1v1 games
- update simulateTurnControl for 1v1 Jack logic
- adjust test to reflect draw mechanic
- add regression test for 1v1 Jack behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68531a0b3bcc832e8a20ed5c7f9a587d