### PR TITLE
Fix Jack skip handling in 1v1 games

### DIFF
--- a/crazy8s-game/backend/src/models/game.js
+++ b/crazy8s-game/backend/src/models/game.js
@@ -338,13 +338,10 @@ class Game {
 
         switch (card.rank) {
             case 'Jack': // Skip
-                if (this.activePlayers.length === 2) {
-                    // In 1v1, Jack acts as a normal card (no skip effect)
-                    // Turn will pass normally after this play
-                } else {
-                    // Skip the next player in multiplayer games
-                    this.nextPlayer();
-                }
+                // Always skip the next player
+                this.nextPlayer();
+                // In a 1v1 game, the outer nextPlayer call will rotate
+                // back to the current player, effectively keeping the turn
                 break;
 
             case 'Queen': // Reverse
@@ -445,13 +442,8 @@ class Game {
         for (const card of cardStack) {
             switch (card.rank) {
                 case 'Jack':
-                    if (isOneVsOne) {
-                        // In 1v1, Jack acts as a normal card (turn passes)
-                        currentPlayerHasTurn = false;
-                    } else {
-                        // Jack skips opponent, back to us
-                        currentPlayerHasTurn = true;
-                    }
+                    // Jack always skips the next player and returns turn
+                    currentPlayerHasTurn = true;
                     break;
                     
                 case 'Queen':
@@ -497,13 +489,14 @@ class Game {
             
             switch (card.rank) {
                 case 'Jack': // Skip
+                    console.log('    Jack: Skipping next player');
+                    this.nextPlayer();
                     if (this.activePlayers.length === 2) {
-                        console.log('    Jack (1v1): Acts as normal card');
-                        currentPlayerHasTurn = false;
-                    } else {
-                        console.log('    Jack: Skipping next player');
-                        // Skip one player and end our turn
+                        // In 1v1, skip opponent and keep turn
                         this.nextPlayer();
+                        currentPlayerHasTurn = true;
+                    } else {
+                        // In multiplayer, turn moves to the following player
                         currentPlayerHasTurn = false;
                     }
                     break;

--- a/crazy8s-game/backend/tests/game.test.js
+++ b/crazy8s-game/backend/tests/game.test.js
@@ -239,7 +239,7 @@ describe('Game Class Tests', () => {
             }
         });
 
-        test('Jack should pass turn in 1v1 game', () => {
+        test('Jack should keep turn in 1v1 game', () => {
             const duelGame = new Game(['p1', 'p2'], ['Alice', 'Bob']);
             duelGame.startGame();
             const jack = { suit: 'Hearts', rank: 'Jack' };
@@ -249,7 +249,7 @@ describe('Game Class Tests', () => {
             const initialIndex = duelGame.currentPlayerIndex;
             const result = duelGame.playCard(duelGame.players[0].id, jack);
             expect(result.success).toBe(true);
-            expect(duelGame.currentPlayerIndex).toBe((initialIndex + 1) % 2);
+            expect(duelGame.currentPlayerIndex).toBe(initialIndex);
         });
 
         test('should handle Queen (Reverse)', () => {


### PR DESCRIPTION
## Summary
- ensure Jack skips and returns turn in 1v1 games
- adjust stacked special card logic for Jack
- update simulation logic to match frontend
- update tests for new 1v1 Jack behavior

## Testing
- `npm test` *(fails: Performance and Stress Tests due to time >500ms)*

------
https://chatgpt.com/codex/tasks/task_e_6854bb47d748832ea3d13744d40a3970