### PR TITLE
Add customizable turn timer controls

### DIFF
--- a/crazy8s-game/frontend/src/components/App.js
+++ b/crazy8s-game/frontend/src/components/App.js
@@ -655,6 +655,180 @@ const Settings = ({ isOpen, onClose, settings, onSettingsChange }) => {
           </div>
         </div>
 
+        {/* Timer Settings Section */}
+        <div style={{ marginBottom: '25px' }}>
+          <h3 style={{ color: '#2c3e50', marginBottom: '15px' }}>⏰ Turn Timer</h3>
+
+          {/* Enable Timer Toggle */}
+          <div style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            marginBottom: '15px',
+            padding: '10px',
+            backgroundColor: '#f8f9fa',
+            borderRadius: '8px'
+          }}>
+            <div>
+              <div style={{ fontWeight: 'bold', marginBottom: '2px' }}>Enable Turn Timer</div>
+              <div style={{ fontSize: '12px', color: '#6c757d' }}>
+                Show countdown timer and auto-draw when time expires
+              </div>
+            </div>
+            <label style={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}>
+              <input
+                type="checkbox"
+                checked={settings.enableTimer}
+                onChange={(e) => handleSettingChange('enableTimer', e.target.checked)}
+                style={{ marginRight: '8px', transform: 'scale(1.2)' }}
+              />
+            </label>
+          </div>
+
+          {/* Timer Duration Controls - Only show when timer is enabled */}
+          {settings.enableTimer && (
+            <>
+              {/* Preset Duration Buttons */}
+              <div style={{
+                padding: '15px',
+                backgroundColor: '#f8f9fa',
+                borderRadius: '8px',
+                marginBottom: '15px'
+              }}>
+                <div style={{ fontWeight: 'bold', marginBottom: '10px' }}>Quick Presets:</div>
+                <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', marginBottom: '15px' }}>
+                  {[30, 60, 90, 120, 180].map(duration => (
+                    <button
+                      key={duration}
+                      onClick={() => handleSettingChange('timerDuration', duration)}
+                      style={{
+                        padding: '6px 12px',
+                        backgroundColor: settings.timerDuration === duration ? '#3498db' : '#e9ecef',
+                        color: settings.timerDuration === duration ? '#fff' : '#495057',
+                        border: 'none',
+                        borderRadius: '15px',
+                        cursor: 'pointer',
+                        fontSize: '12px',
+                        fontWeight: 'bold',
+                        transition: 'all 0.2s ease'
+                      }}
+                    >
+                      {duration < 60 ? `${duration}s` : `${Math.floor(duration/60)}:${(duration%60).toString().padStart(2,'0')}`}
+                    </button>
+                  ))}
+                </div>
+
+                {/* Slider Control */}
+                <div style={{ marginBottom: '15px' }}>
+                  <div style={{ 
+                    display: 'flex', 
+                    justifyContent: 'space-between', 
+                    alignItems: 'center',
+                    marginBottom: '8px'
+                  }}>
+                    <label style={{ fontWeight: 'bold', fontSize: '14px' }}>
+                      Timer Duration: {Math.floor(settings.timerDuration/60)}:{(settings.timerDuration%60).toString().padStart(2,'0')}
+                    </label>
+                    <span style={{ fontSize: '12px', color: '#6c757d' }}>
+                      ({settings.timerDuration} seconds)
+                    </span>
+                  </div>
+                  <input
+                    type="range"
+                    min="15"
+                    max="300"
+                    step="5"
+                    value={settings.timerDuration}
+                    onChange={(e) => handleSettingChange('timerDuration', parseInt(e.target.value))}
+                    style={{
+                      width: '100%',
+                      height: '6px',
+                      borderRadius: '3px',
+                      background: `linear-gradient(to right, #3498db 0%, #3498db ${((settings.timerDuration-15)/(300-15))*100}%, #ddd ${((settings.timerDuration-15)/(300-15))*100}%, #ddd 100%)`,
+                      outline: 'none',
+                      cursor: 'pointer'
+                    }}
+                  />
+                  <div style={{ 
+                    display: 'flex', 
+                    justifyContent: 'space-between', 
+                    fontSize: '10px', 
+                    color: '#6c757d',
+                    marginTop: '5px'
+                  }}>
+                    <span>15s</span>
+                    <span>5:00</span>
+                  </div>
+                </div>
+
+                {/* Custom Input */}
+                <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+                  <label style={{ fontWeight: 'bold', fontSize: '14px', minWidth: 'fit-content' }}>
+                    Custom:
+                  </label>
+                  <input
+                    type="number"
+                    min="15"
+                    max="300"
+                    value={settings.timerDuration}
+                    onChange={(e) => {
+                      const value = Math.max(15, Math.min(300, parseInt(e.target.value) || 15));
+                      handleSettingChange('timerDuration', value);
+                    }}
+                    style={{
+                      padding: '8px 12px',
+                      border: '2px solid #ddd',
+                      borderRadius: '6px',
+                      fontSize: '14px',
+                      width: '80px',
+                      textAlign: 'center'
+                    }}
+                  />
+                  <span style={{ fontSize: '12px', color: '#6c757d' }}>seconds</span>
+                </div>
+              </div>
+
+              {/* Warning Time Setting */}
+              <div style={{
+                padding: '15px',
+                backgroundColor: '#fff3cd',
+                borderRadius: '8px',
+                border: '1px solid #ffeaa7'
+              }}>
+                <div style={{ fontWeight: 'bold', marginBottom: '10px', color: '#856404' }}>
+                  ⚠️ Warning Threshold:
+                </div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: '8px' }}>
+                  <span style={{ fontSize: '14px', minWidth: 'fit-content' }}>Show warning at:</span>
+                  <input
+                    type="number"
+                    min="5"
+                    max={Math.floor(settings.timerDuration * 0.5)}
+                    value={settings.timerWarningTime}
+                    onChange={(e) => {
+                      const maxWarning = Math.floor(settings.timerDuration * 0.5);
+                      const value = Math.max(5, Math.min(maxWarning, parseInt(e.target.value) || 15));
+                      handleSettingChange('timerWarningTime', value);
+                    }}
+                    style={{
+                      padding: '6px 10px',
+                      border: '2px solid #ddd',
+                      borderRadius: '4px',
+                      fontSize: '12px',
+                      width: '60px',
+                      textAlign: 'center'
+                    }}
+                  />
+                  <span style={{ fontSize: '12px', color: '#856404' }}>seconds remaining</span>
+                </div>
+                <div style={{ fontSize: '11px', color: '#856404', fontStyle: 'italic' }}>
+                  Timer will turn red and pulse when warning threshold is reached
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+
         {/* Close Button */}
         <div style={{ textAlign: 'center' }}>
           <button
@@ -883,7 +1057,10 @@ const App = () => {
   const [settings, setSettings] = useState({
     sortByRank: false,
     groupBySuit: false,
-    experiencedMode: false
+    experiencedMode: false,
+    enableTimer: true,
+    timerDuration: 60,
+    timerWarningTime: 15
   });
   const [copiedGameId, setCopiedGameId] = useState(false);
   const [hasDrawnThisTurn, setHasDrawnThisTurn] = useState(false);
@@ -898,7 +1075,16 @@ const App = () => {
       const savedSettings = localStorage.getItem(`crazy8s_settings_${playerId}`);
       if (savedSettings) {
         try {
-          setSettings(JSON.parse(savedSettings));
+          const parsed = JSON.parse(savedSettings);
+          setSettings({
+            sortByRank: false,
+            groupBySuit: false,
+            experiencedMode: false,
+            enableTimer: true,
+            timerDuration: 60,
+            timerWarningTime: 15,
+            ...parsed
+          });
         } catch (error) {
           console.log('Error loading settings:', error);
         }
@@ -906,13 +1092,34 @@ const App = () => {
     }
   }, [playerId]);
 
+  const validateTimerSettings = (newSettings) => {
+    const validated = { ...newSettings };
+    if (validated.timerDuration < 15) validated.timerDuration = 15;
+    if (validated.timerDuration > 300) validated.timerDuration = 300;
+    const maxWarning = Math.floor(validated.timerDuration * 0.5);
+    if (validated.timerWarningTime < 5) validated.timerWarningTime = 5;
+    if (validated.timerWarningTime > maxWarning) validated.timerWarningTime = maxWarning;
+    return validated;
+  };
+
   // Save settings to localStorage whenever they change
   const handleSettingsChange = (newSettings) => {
-    setSettings(newSettings);
+    const validatedSettings = validateTimerSettings(newSettings);
+    setSettings(validatedSettings);
     if (playerId) {
-      localStorage.setItem(`crazy8s_settings_${playerId}`, JSON.stringify(newSettings));
+      localStorage.setItem(`crazy8s_settings_${playerId}`, JSON.stringify(validatedSettings));
     }
   };
+
+  useEffect(() => {
+    console.log('⏰ Timer Settings Updated:', {
+      enableTimer: settings.enableTimer,
+      timerDuration: settings.timerDuration,
+      timerWarningTime: settings.timerWarningTime,
+      isActive: timerActive,
+      currentTime: turnTimer
+    });
+  }, [settings.enableTimer, settings.timerDuration, settings.timerWarningTime, timerActive, turnTimer]);
 
   // Copy game ID to clipboard
   const copyGameId = async () => {
@@ -1006,7 +1213,7 @@ const App = () => {
     newSocket.on('cardPlayed', (data) => {
       console.log('🃏 Card played:', data);
       setToast({ message: `${data.playerName} played: ${data.cardsPlayed.join(', ')}`, type: 'info' });
-      setTurnTimer(60);
+      setTurnTimer(settings.timerDuration);
       setTimerWarning(false);
     });
 
@@ -1023,7 +1230,7 @@ const App = () => {
       setIsDrawing(false);
       setHasDrawnThisTurn(true);
 
-      setTurnTimer(60);
+      setTurnTimer(settings.timerDuration);
       setTimerWarning(false);
 
       if (data.canPlayDrawnCard && data.playableDrawnCards.length > 0) {
@@ -1214,7 +1421,7 @@ const App = () => {
 }, [playerHand, gameState, selectedCards, canStackCards]);
 
 useEffect(() => {
-  if (!timerActive || gameState?.currentPlayerId !== playerId || gameState?.gameState !== 'playing') {
+  if (!timerActive || !settings.enableTimer || gameState?.currentPlayerId !== playerId || gameState?.gameState !== 'playing') {
     return;
   }
   
@@ -1233,17 +1440,17 @@ useEffect(() => {
         }
         setTimerActive(false);
         setTimerWarning(false);
-        return 60; // Reset for next turn
+        return settings.timerDuration; // Use settings instead of hardcoded 60
       }
-      if (prev <= 15 && !timerWarning) {
+      if (prev <= settings.timerWarningTime && !timerWarning) {
         setTimerWarning(true);
       }
       return prev - 1;
     });
   }, 1000);
-  
+
   return () => clearInterval(interval);
-}, [timerActive, gameState?.currentPlayerId, playerId, gameState?.gameState, timerWarning, socket, gameState?.gameId]);
+}, [timerActive, settings.enableTimer, gameState?.currentPlayerId, playerId, gameState?.gameState, timerWarning, socket, gameState?.gameId, settings.timerDuration, settings.timerWarningTime]);
 
 // Timer reset logic
 useEffect(() => {
@@ -1254,15 +1461,15 @@ useEffect(() => {
       setTimerWarning(false);
     } else {
       // It's my turn - start timer
-      setTurnTimer(60);
-      setTimerActive(true);
+      setTurnTimer(settings.enableTimer ? settings.timerDuration : 60);
+      setTimerActive(settings.enableTimer);
       setTimerWarning(false);
     }
   } else {
     setTimerActive(false);
     setTimerWarning(false);
   }
-}, [gameState?.currentPlayerId, gameState?.gameState, playerId]);
+}, [gameState?.currentPlayerId, gameState?.gameState, playerId, settings.enableTimer, settings.timerDuration]);
 
   const startGame = () => {
     console.log('🚀 Starting game:', gameState?.gameId);
@@ -1369,7 +1576,7 @@ useEffect(() => {
       setHasDrawnThisTurn(false);
       setIsDrawing(false);
 
-      setTurnTimer(60);
+      setTurnTimer(settings.timerDuration);
       setTimerWarning(false);
     }
   };
@@ -1385,8 +1592,8 @@ useEffect(() => {
     setShowSuitSelector(false);
     setHasDrawnThisTurn(false);
     setIsDrawing(false);
-    setTurnTimer(60);
-    setTimerWarning(false);
+      setTurnTimer(settings.timerDuration);
+      setTimerWarning(false);
   };
 
   const drawCard = () => {
@@ -1412,6 +1619,50 @@ useEffect(() => {
     setHasDrawnThisTurn(false);
     setIsDrawing(false);
   };
+
+  const sliderStyles = `
+    input[type="range"] {
+      -webkit-appearance: none;
+      appearance: none;
+      height: 6px;
+      border-radius: 3px;
+      outline: none;
+      cursor: pointer;
+    }
+
+    input[type="range"]::-webkit-slider-thumb {
+      -webkit-appearance: none;
+      appearance: none;
+      width: 18px;
+      height: 18px;
+      border-radius: 50%;
+      background: #3498db;
+      cursor: pointer;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+      transition: all 0.2s ease;
+    }
+
+    input[type="range"]::-webkit-slider-thumb:hover {
+      transform: scale(1.1);
+      box-shadow: 0 4px 8px rgba(0,0,0,0.3);
+    }
+
+    input[type="range"]::-moz-range-thumb {
+      width: 18px;
+      height: 18px;
+      border-radius: 50%;
+      background: #3498db;
+      cursor: pointer;
+      border: none;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+      transition: all 0.2s ease;
+    }
+
+    input[type="range"]::-moz-range-thumb:hover {
+      transform: scale(1.1);
+      box-shadow: 0 4px 8px rgba(0,0,0,0.3);
+    }
+  `;
 
   if (!isConnected) {
     return (
@@ -1746,10 +1997,10 @@ useEffect(() => {
             </div>
             
             {/* TIMER COMPONENT ADDED HERE */}
-            <TurnTimer 
+            <TurnTimer
             timeLeft={turnTimer}
             isWarning={timerWarning}
-            isVisible={player.isCurrentPlayer && gameState.gameState === 'playing'}
+            isVisible={player.isCurrentPlayer && gameState.gameState === 'playing' && settings.enableTimer}
             />
         </div>
         ))}
@@ -2002,7 +2253,7 @@ useEffect(() => {
       )}
 
       {/* Chat */}
-      <div style={{ 
+      <div style={{
         position: 'fixed',
         bottom: '20px',
         right: '20px',
@@ -2032,6 +2283,8 @@ useEffect(() => {
           transform: translateY(-10px);
           box-shadow: 0 6px 16px rgba(52, 152, 219, 0.4);
         }
+
+        ${sliderStyles}
       `}</style>
     </div>
   );


### PR DESCRIPTION
## Summary
- integrate timer settings in game state
- implement slider, presets, and inputs in Settings modal
- persist timer settings in local storage with validation
- apply timer settings to countdown logic and visibility
- add styling for range slider

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685ab76c2584832e9fa086031fbdee42