### PR TITLE
Fix multi-card stack turn logic

### DIFF
--- a/crazy8s-game/backend/tests/game.test.js
+++ b/crazy8s-game/backend/tests/game.test.js
@@ -312,12 +312,41 @@ describe('Game Class Tests', () => {
         test('should reject 8 without declared suit', () => {
             const eight = { suit: 'Hearts', rank: '8' };
             const currentPlayer = game.getCurrentPlayer();
-            
+
             currentPlayer.hand.push(eight);
-            
+
             const result = game.playCard(currentPlayer.id, eight);
-            
+
             expect(result.success).toBe(false);
+        });
+    });
+
+    describe('Stacked Special Sequences', () => {
+        beforeEach(() => {
+            game.startGame();
+            // Force turn state
+            game.currentPlayerIndex = 2; // Third player
+            game.direction = -1;
+            game.discardPile = [{ suit: 'Clubs', rank: '5' }];
+        });
+
+        test('complex stack should pass turn correctly', () => {
+            const player = game.getPlayerById('p3');
+            const stack = [
+                { suit: 'Clubs', rank: 'Jack' },
+                { suit: 'Hearts', rank: 'Jack' },
+                { suit: 'Hearts', rank: 'Queen' },
+                { suit: 'Diamonds', rank: 'Queen' },
+                { suit: 'Diamonds', rank: '10' }
+            ];
+
+            player.hand.push(...stack);
+
+            const result = game.playCard(player.id, stack);
+
+            expect(result.success).toBe(true);
+            expect(game.direction).toBe(-1); // two reverses cancel
+            expect(game.currentPlayerIndex).toBe(1); // turn should pass to player 2
         });
     });
 


### PR DESCRIPTION
## Summary
- adjust `handleMultipleSpecialCards` to compute the next player using a local simulation instead of mutating turn order mid-play
- clear drawn flags and return final next player index
- add regression test for stacked special sequence

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ad9d57398832e85fdc12e5c71ca86