### PR TITLE
Implement auto pass timer for unplayable draws

### DIFF
--- a/crazy8s-game/backend/src/server.js
+++ b/crazy8s-game/backend/src/server.js
@@ -67,6 +67,11 @@ io.on('connection', (socket) => {
             // Create new game with this player
             const game = new Game([socket.id], [playerName]);
             Game.addGame(game);
+            game.onAutoPass = (playerId) => {
+                const player = game.getPlayerById(playerId);
+                broadcastGameState(game.id);
+                io.to(game.id).emit('playerAutoPassed', { playerName: player?.name });
+            };
             
             // Store player info
             connectedPlayers.set(socket.id, {
@@ -102,6 +107,11 @@ io.on('connection', (socket) => {
             const game = new Game(playerIds, playerNames);
             game.debugMode = debugMode;
             Game.addGame(game);
+            game.onAutoPass = (playerId) => {
+                const player = game.getPlayerById(playerId);
+                broadcastGameState(game.id);
+                io.to(game.id).emit('playerAutoPassed', { playerName: player?.name });
+            };
 
             game.gameState = 'playing';
             game.currentPlayerIndex = 0;

--- a/crazy8s-game/backend/tests/game.test.js
+++ b/crazy8s-game/backend/tests/game.test.js
@@ -352,12 +352,30 @@ describe('Game Class Tests', () => {
             const player = game.getPlayerById('p1');
             game.drawStack = 4;
             const initialHandSize = player.hand.length;
-            
+
             const result = game.drawCards('p1');
-            
+
             expect(result.success).toBe(true);
             expect(player.hand).toHaveLength(initialHandSize + 4);
             expect(game.drawStack).toBe(0);
+        });
+
+        test('should auto pass turn if no playable cards after draw', () => {
+            jest.useFakeTimers();
+            const player = game.getPlayerById('p1');
+            game.discardPile = [{ suit: 'Clubs', rank: '5' }];
+            player.hand = [{ suit: 'Hearts', rank: '2' }];
+            game.drawPile = [{ suit: 'Diamonds', rank: '7' }];
+
+            const result = game.drawCards('p1', 1);
+            expect(result.success).toBe(true);
+            expect(game.pendingTurnPass).toBe('p1');
+
+            jest.advanceTimersByTime(5000);
+
+            expect(game.pendingTurnPass).toBe(null);
+            expect(game.getCurrentPlayer().id).toBe('p2');
+            jest.useRealTimers();
         });
     });
 


### PR DESCRIPTION
## Summary
- add auto pass timers to Game class
- schedule auto pass in drawCards when player has no playable moves
- expose callbacks for server to broadcast auto pass events
- hook auto pass callbacks in server creation flows
- clear timers when rounds reset
- test automatic passing after 5 seconds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c0273b380832e9380846427cb9cc4